### PR TITLE
fix: add repository checkout step to auto-merge workflow

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -30,6 +30,11 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
 
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+
       - name: Fetch Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v2


### PR DESCRIPTION
## Summary
Add checkout action with GitHub App token to resolve git repository access issues in the auto-merge workflow.

## Problem
The workflow was failing with "fatal: not a git repository" error when executing gh CLI commands because the repository was not checked out.

## Solution
- Add `actions/checkout@v4` step with GitHub App token
- Position checkout after token generation to use consistent authentication
- Ensures gh CLI commands have access to git repository context

## Test plan
- Verify workflow runs without git repository errors
- Confirm gh CLI commands (pr review, pr merge, pr comment) execute successfully