### PR TITLE
fix: specify merge strategy for auto-merge command

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -68,8 +68,7 @@ jobs:
             --body "✅ Auto-approved ${{ steps.metadata.outputs.update-type }} update for ${{ steps.metadata.outputs.dependency-names }}"
 
           # Enable auto-merge
-          gh pr merge ${{ github.event.pull_request.number }} --auto
-
+          gh pr merge ${{ github.event.pull_request.number }} --auto --merge
           # Add success comment
           gh pr comment ${{ github.event.pull_request.number }} \
             --body "🚀 Auto-merge enabled for this ${{ steps.metadata.outputs.update-type }} update. Will merge once all checks pass."


### PR DESCRIPTION
## Summary
Add explicit merge strategy flag to resolve auto-merge command failure in non-interactive mode.

## Problem
The `gh pr merge --auto` command was failing with error: "merge, rebase, or squash required when not running interactively".

## Solution
- Add `--merge` flag to explicitly specify merge strategy
- Maintains auto-merge functionality while satisfying CLI requirements
- Uses standard merge commits to preserve commit history

## Test plan
- Verify auto-merge workflow executes without merge strategy errors
- Confirm PRs are merged using merge commit strategy